### PR TITLE
Fix Android compatibility with CSV tile layers

### DIFF
--- a/src/TMXTile/Map/TMXData.cs
+++ b/src/TMXTile/Map/TMXData.cs
@@ -61,7 +61,8 @@ namespace TMXTile
         public List<TMXChunk> Chunks { get; set; }
 
         [XmlElement(ElementName = "tile")]
-        public List<TMXTile> RawTiles
+        [Obsolete("This method only exists for (de)serialization; code should use the normalized " + nameof(Tiles) + " instead.")]
+        public List<TMXTile> XmlTiles
         {
             get
             {
@@ -70,18 +71,24 @@ namespace TMXTile
                 else
                     return null;
             }
-            set => Tiles = value;
+            set
+            {
+                // This field only applies in XML mode, but on Android it will be called for other encodings anyway with an empty list.
+                if (TMXParser.CurrentEncoding == DataEncodingType.XML)
+                    Tiles = value;
+            }
         }
 
-        [XmlIgnore]
-        public List<TMXTile> Tiles { get; set; }
-
-        [XmlText()]
+        [XmlText]
+        [Obsolete("This method only exists for (de)serialization; code should use the normalized " + nameof(Tiles) + " instead.")]
         public string Raw
         {
             get => encode();
             set => decode(value);
         }
+
+        [XmlIgnore]
+        public List<TMXTile> Tiles { get; private set; } = new List<TMXTile>();
 
         private void copyStream(System.IO.Stream input, System.IO.Stream output)
         {

--- a/src/TMXTile/TMXFormat.cs
+++ b/src/TMXTile/TMXFormat.cs
@@ -586,10 +586,7 @@ namespace TMXTile
                 tiledLayer1.Name = layer.Id;
                 tiledLayer1.Width = layer.LayerWidth;
                 tiledLayer1.Height = layer.LayerHeight;
-                tiledLayer1.Data = new TMXData()
-                {
-                    Tiles = new List<TMXTile>()
-                };
+                tiledLayer1.Data = new TMXData();
             var props = new List<TMXProperty>();
                 foreach (var prop in layer.Properties) {
                     if (prop.Key == "@OffsetX")


### PR DESCRIPTION
This fixes maps with the CSV tile layer format always loading as a tileless black void on Android.