### PR TITLE
Fix tiles being ignored due to [Obsolete] attribute

### DIFF
--- a/src/TMXTile/Map/TMXChunk.cs
+++ b/src/TMXTile/Map/TMXChunk.cs
@@ -22,8 +22,8 @@ namespace TMXTile
         [XmlAttribute(AttributeName = "height")]
         public int Height { get; set; }
 
+        /// <summary>This property is for (de)serialization; code should use the normalized <see cref="Tiles"/> instead.</summary>
         [XmlElement(ElementName = "tile")]
-        [Obsolete("This method only exists for (de)serialization; code should use the normalized " + nameof(Tiles) + " instead.")]
         public List<TMXTile> XmlTiles
         {
             get
@@ -41,9 +41,9 @@ namespace TMXTile
             }
         }
 
+        /// <summary>This property is for (de)serialization; code should use the normalized <see cref="Tiles"/> instead.</summary>
         [XmlText]
-        [Obsolete("This method only exists for (de)serialization; code should use the normalized " + nameof(Tiles) + " instead.")]
-        public string Raw
+        public string BodyTiles
         {
             get => encode();
             set => decode(value);

--- a/src/TMXTile/Map/TMXData.cs
+++ b/src/TMXTile/Map/TMXData.cs
@@ -60,8 +60,8 @@ namespace TMXTile
         [XmlElement(ElementName = "chunk")]
         public List<TMXChunk> Chunks { get; set; }
 
+        /// <summary>This property is for (de)serialization; code should use the normalized <see cref="Tiles"/> instead.</summary>
         [XmlElement(ElementName = "tile")]
-        [Obsolete("This method only exists for (de)serialization; code should use the normalized " + nameof(Tiles) + " instead.")]
         public List<TMXTile> XmlTiles
         {
             get
@@ -79,9 +79,9 @@ namespace TMXTile
             }
         }
 
+        /// <summary>This property is for (de)serialization; code should use the normalized <see cref="Tiles"/> instead.</summary>
         [XmlText]
-        [Obsolete("This method only exists for (de)serialization; code should use the normalized " + nameof(Tiles) + " instead.")]
-        public string Raw
+        public string BodyTiles
         {
             get => encode();
             set => decode(value);


### PR DESCRIPTION
Ignoring obsolete properties is [apparently an XmlSerializer feature](https://stackoverflow.com/questions/331013/obsolete-attribute-causes-property-to-be-ignored-by-xmlserialization).